### PR TITLE
Remove unnecessary dependencies from examples

### DIFF
--- a/expo/package.json
+++ b/expo/package.json
@@ -11,12 +11,10 @@
   "dependencies": {
     "@tsconfig/react-native": "^2.0.2",
     "@types/react-native": "~0.69.1",
-    "base-64": "^1.0.0",
     "electric-sql": "^0.2.2",
     "expo": "~46.0.16",
     "expo-sqlite": "^10.3.0",
     "expo-status-bar": "~1.4.0",
-    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "react": "18.0.0",
     "react-native": "0.69.6",
     "typescript": "^4.8.4"

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -10,9 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "base-64": "^1.0.0",
     "electric-sql": "^0.2.2",
-    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "react": "18.1.0",
     "react-native": "0.70.1",
     "react-native-sqlite-storage": "^6.0.1"

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@aphro/absurd-sql": "^0.0.53",
     "@aphro/sql.js": "^1.7.0",
-    "base-64": "^1.0.0",
     "electric-sql": "^0.2.2",
     "fs-extra": "^10.0.0",
     "react": "^17.0.2",


### PR DESCRIPTION
Examples have redundant dependencies to packages that are used only by electric-sql