### PR TITLE
Make the quickstart example work even when not on localhost

### DIFF
--- a/quickstart/src/Example.electrified.tsx
+++ b/quickstart/src/Example.electrified.tsx
@@ -30,6 +30,8 @@ import { ElectricProvider, useElectric, useElectricQuery } from 'electric-sql/re
 
 import config from '../.electric/@config'
 
+import { genUUID } from 'electric-sql/dist/util/random'
+
 const locateOpts = {
   locateFile: (file: string) => `/${file}`
 }
@@ -67,7 +69,7 @@ const ExampleComponent = () => {
   const { results } = useElectricQuery('SELECT value FROM items', [])
 
   const addItem = () => {
-    db.run('INSERT INTO items VALUES(?)', [crypto.randomUUID()])
+    db.run('INSERT INTO items VALUES(?)', [genUUID()])
   }
 
   const clearItems = () => {

--- a/quickstart/src/Example.original.tsx
+++ b/quickstart/src/Example.original.tsx
@@ -12,6 +12,8 @@
 import React, { useContext, useEffect, useState } from 'react'
 import './Example.css'
 
+import { genUUID } from 'electric-sql/dist/util/random'
+
 import initSqlJs from '@aphro/sql.js'
 
 const DbContext = React.createContext(undefined)
@@ -79,7 +81,7 @@ const ExampleComponent = () => {
   }, [counter])
 
   const addItem = () => {
-    db.run('INSERT INTO items VALUES(?)', [crypto.randomUUID()])
+    db.run('INSERT INTO items VALUES(?)', [genUUID()])
 
     triggerQuery()
   }

--- a/quickstart/src/Example.tsx
+++ b/quickstart/src/Example.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useEffect, useState } from 'react'
 import './Example.css'
 
+import { genUUID } from 'electric-sql/dist/util/random'
+
 // XXX Uncomment these imports.
 // import { ElectrifiedDatabase, initElectricSqlJs } from 'electric-sql/browser'
 // import { ElectricProvider, useElectric, useElectricQuery } from 'electric-sql/react'
@@ -100,7 +102,7 @@ const ExampleComponent = () => {
   // const { results } = useElectricQuery('SELECT value FROM items', [])
 
   const addItem = () => {
-    db.run('INSERT INTO items VALUES(?)', [crypto.randomUUID()])
+    db.run('INSERT INTO items VALUES(?)', [genUUID()])
 
     // XXX You no longer need this.
     triggerQuery()

--- a/web/README.md
+++ b/web/README.md
@@ -89,7 +89,7 @@ const ExampleComponent = () => {
   const addItem = async () => {
     await electric.adapter.run({
         sql: 'INSERT INTO items VALUES(?)',
-        args: [crypto.randomUUID()]
+        args: [genUUID()]
       }
     )
     electric.notifier.potentiallyChanged()

--- a/web/src/Example.tsx
+++ b/web/src/Example.tsx
@@ -7,6 +7,8 @@ import { ElectricProvider, useElectric, useElectricQuery } from 'electric-sql/re
 import config from '../.electric/@config'
 import { ElectricNamespace } from "electric-sql"
 
+import { genUUID } from 'electric-sql/dist/util/random'
+
 export const Example = () => {
   const [ db, setDb ] = useState<ElectricDatabase & { electric: ElectricNamespace }>()
 
@@ -39,7 +41,7 @@ const ExampleComponent = () => {
   const addItem = async () => {
     await electric.adapter.run({
         sql: 'INSERT INTO items VALUES(?)',
-        args: [crypto.randomUUID()]
+        args: [genUUID()]
       }
     )
     electric.notifier.potentiallyChanged() // need to be called manually because the wa-sqlite driver is not proxied


### PR DESCRIPTION
I usually use a different server even when testing locally, so `crypto.randomUUID` is not available, as it is available only in trusted environments. Because the example only needs random strings, I think `Math.random().toString()` suffices, even though it may be a little ugly.

This PR is made in case there are more people like me, testing locally using multiple machines.